### PR TITLE
Add SNAP_DB_PG_URL_ALT documentation. Fix 'formated' typo

### DIFF
--- a/source/03-environment_variables.md.erb
+++ b/source/03-environment_variables.md.erb
@@ -42,8 +42,8 @@ Snap will export additional environment variables.
 * ``SNAP_DB_MYSQL_PASSWORD`` - password for MySQL connection
 * ``SNAP_DB_MYSQL_HOST`` - host for MySQL connection
 * ``SNAP_DB_MYSQL_PORT`` - port for MySQL connection
-* ``SNAP_DB_MYSQL_URL`` - a MySQL URL formated for connection
-* ``SNAP_DB_MYSQL_JDBC_URL`` - a JDBC URL formated for connection
+* ``SNAP_DB_MYSQL_URL`` - a MySQL URL formatted for connection
+* ``SNAP_DB_MYSQL_JDBC_URL`` - a JDBC URL formatted for connection
 
 ## For PostgreSQL
 
@@ -51,8 +51,9 @@ Snap will export additional environment variables.
 * ``SNAP_DB_PG_PASSWORD`` - password for PostgreSQL connection
 * ``SNAP_DB_PG_HOST`` - host for PostgreSQL connection
 * ``SNAP_DB_PG_PORT`` - port for PostgreSQL connection
-* ``SNAP_DB_PG_URL`` - a PostgreSQL URL formated for connection
-* ``SNAP_DB_PG_JDBC_URL`` - a JDBC URL formated for connection
+* ``SNAP_DB_PG_URL`` - a PostgreSQL URL formatted for connection
+* ``SNAP_DB_PG_URL_ALT`` - a PostgreSQL URL formatted for connection (uses the postgres:// URI scheme)
+* ``SNAP_DB_PG_JDBC_URL`` - a JDBC URL formatted for connection
 
 # Other variables
 


### PR DESCRIPTION
I happily noticed that Snap exposes another environment variable (SNAP_DB_PG_URL_ALT) that was not documented.
