### PR TITLE
Add BuildCheckerApp in docs

### DIFF
--- a/source/70-notifications/50-cctray_notifications.md.erb
+++ b/source/70-notifications/50-cctray_notifications.md.erb
@@ -1,9 +1,9 @@
 ---
 title:  "Polling project status using CCTray"
-doc_title:  "Using CCTray/CCMenu notifications Snap CI builds"
+doc_title:  "Using CCTray notifications Snap CI builds"
 ---
 
-You may poll the status of one or all your projects by using the CCTray API, this API can be consumed by a lot of CI monitoring tools like [CCMenu](http://ccmenu.sourceforge.net)(OS X), [CCTray](http://ccnet.sourceforge.net/CCNET/CCTray.html)(Windows), [BuildNotify](https://bitbucket.org/Anay/buildnotify/wiki/Home)(GNU/Linux)
+You may poll the status of one or all your projects by using the CCTray API, this API can be consumed by a lot of CI monitoring tools like [CCMenu](http://ccmenu.sourceforge.net)(OS X), [CCTray](http://ccnet.sourceforge.net/CCNET/CCTray.html)(Windows), [BuildNotify](https://bitbucket.org/Anay/buildnotify/wiki/Home)(GNU/Linux) and [BuildCheckerApp](https://github.com/willmendesneto/build-checker-app#readme) for cross platform support (OS X, Windows and GNU/Linux)
 
 
 Snap provides CCTray feeds for individual projects and also for all projects on your dashboard. Personalized URLs for the feed are available on the project build history page and dashboard.


### PR DESCRIPTION
- Add [BuildCheckerApp](https://github.com/willmendesneto/build-checker-app#readme) in docs page;
- Removes `CCMenu` reference in `doc_title`;